### PR TITLE
fix 'constant 2147483648 overflows int'

### DIFF
--- a/ds/zset/sortedset.go
+++ b/ds/zset/sortedset.go
@@ -288,7 +288,7 @@ type GetByScoreRangeOptions struct {
 //
 // Time complexity of this method is : O(log(N)).
 func (ss *SortedSet) GetByScoreRange(start SCORE, end SCORE, options *GetByScoreRangeOptions) []*SortedSetNode {
-	limit := 1<<31 - 1
+	limit := (1 << 31) - 1
 	if options != nil && options.Limit > 0 {
 		limit = options.Limit
 	}


### PR DESCRIPTION
**Describe the bug**
I got a `constant 2147483648 overflows int` message in `go build` process for the ARM 32-bit architecture.

**To Reproduce**
Steps to reproduce the behavior:
```console
$ git clone https://github.com/michilu/boilerplate
$ cd boilerplate
$ git checkout 23bee11
$ GO111MODULE=on GOOS=linux GOARCH=arm go build
```

**Expected behavior**
```conosle
$ GO111MODULE=on GOOS=linux GOARCH=arm go build
$
```
no errors.

**What actually happens**
```console
$ GO111MODULE=on GOOS=linux GOARCH=arm go build
# github.com/xujiajun/nutsdb/ds/zset
../../go/pkg/mod/github.com/xujiajun/nutsdb@v0.4.0/ds/zset/sortedset.go:291:13: constant 2147483648 overflows int
```

**Screenshots**
N/A

**please complete the following information :**
 - OS:
   - macOS 10.13.6
   - Ubuntu 16.04
 - NutsDB Version: v0.4.0 14f036b (2019-08-30T02:35:07Z)


**Additional context**
N/A