### PR TITLE
made meta.txId, timestamp and ds available across packages

### DIFF
--- a/bptree_test.go
+++ b/bptree_test.go
@@ -287,7 +287,7 @@ func TestIsExpired(t *testing.T) {
 	record := &Record{
 		H: &Hint{
 			meta: &MetaData{
-				timestamp: 1547707905,
+				Timestamp: 1547707905,
 				TTL:       10,
 			},
 		},

--- a/datafile.go
+++ b/datafile.go
@@ -158,14 +158,14 @@ func (df *DataFile) Close() (err error) {
 // readMetaData returns MetaData at given buf slice.
 func readMetaData(buf []byte) *MetaData {
 	return &MetaData{
-		timestamp:  binary.LittleEndian.Uint64(buf[4:12]),
+		Timestamp:  binary.LittleEndian.Uint64(buf[4:12]),
 		keySize:    binary.LittleEndian.Uint32(buf[12:16]),
 		valueSize:  binary.LittleEndian.Uint32(buf[16:20]),
 		Flag:       binary.LittleEndian.Uint16(buf[20:22]),
 		TTL:        binary.LittleEndian.Uint32(buf[22:26]),
 		bucketSize: binary.LittleEndian.Uint32(buf[26:30]),
 		status:     binary.LittleEndian.Uint16(buf[30:32]),
-		ds:         binary.LittleEndian.Uint16(buf[32:34]),
-		txID:       binary.LittleEndian.Uint64(buf[34:42]),
+		Ds:         binary.LittleEndian.Uint16(buf[32:34]),
+		TxID:       binary.LittleEndian.Uint64(buf[34:42]),
 	}
 }

--- a/datafile_test.go
+++ b/datafile_test.go
@@ -32,7 +32,7 @@ func init() {
 		Meta: &MetaData{
 			keySize:    uint32(len("key_0001")),
 			valueSize:  uint32(len("val_0001")),
-			timestamp:  1547707905,
+			Timestamp:  1547707905,
 			TTL:        Persistent,
 			bucket:     []byte("test_DataFile"),
 			bucketSize: uint32(len("test_datafile")),
@@ -69,7 +69,7 @@ func TestDataFile1(t *testing.T) {
 	}
 
 	e, err = df.ReadAt(0)
-	if err != nil || string(e.Key) != "key_0001" || string(e.Value) != "val_0001" || e.Meta.timestamp != 1547707905 {
+	if err != nil || string(e.Key) != "key_0001" || string(e.Value) != "val_0001" || e.Meta.Timestamp != 1547707905 {
 		t.Error("err TestDataFile_All ReadAt")
 	}
 

--- a/entry.go
+++ b/entry.go
@@ -41,14 +41,14 @@ type (
 	MetaData struct {
 		keySize    uint32
 		valueSize  uint32
-		timestamp  uint64
+		Timestamp  uint64
 		TTL        uint32
 		Flag       uint16 // delete / set
 		bucket     []byte
 		bucketSize uint32
-		txID       uint64
+		TxID       uint64
 		status     uint16 // committed / uncommitted
-		ds         uint16 // data structure
+		Ds         uint16 // data structure
 	}
 )
 
@@ -87,22 +87,22 @@ func (e *Entry) Encode() []byte {
 
 // setEntryHeaderBuf sets the entry header buff.
 func (e *Entry) setEntryHeaderBuf(buf []byte) []byte {
-	binary.LittleEndian.PutUint64(buf[4:12], e.Meta.timestamp)
+	binary.LittleEndian.PutUint64(buf[4:12], e.Meta.Timestamp)
 	binary.LittleEndian.PutUint32(buf[12:16], e.Meta.keySize)
 	binary.LittleEndian.PutUint32(buf[16:20], e.Meta.valueSize)
 	binary.LittleEndian.PutUint16(buf[20:22], e.Meta.Flag)
 	binary.LittleEndian.PutUint32(buf[22:26], e.Meta.TTL)
 	binary.LittleEndian.PutUint32(buf[26:30], e.Meta.bucketSize)
 	binary.LittleEndian.PutUint16(buf[30:32], e.Meta.status)
-	binary.LittleEndian.PutUint16(buf[32:34], e.Meta.ds)
-	binary.LittleEndian.PutUint64(buf[34:42], e.Meta.txID)
+	binary.LittleEndian.PutUint16(buf[32:34], e.Meta.Ds)
+	binary.LittleEndian.PutUint64(buf[34:42], e.Meta.TxID)
 
 	return buf
 }
 
 // IsZero checks if the entry is zero or not.
 func (e *Entry) IsZero() bool {
-	if e.crc == 0 && e.Meta.keySize == 0 && e.Meta.valueSize == 0 && e.Meta.timestamp == 0 {
+	if e.crc == 0 && e.Meta.keySize == 0 && e.Meta.valueSize == 0 && e.Meta.Timestamp == 0 {
 		return true
 	}
 	return false

--- a/entry_test.go
+++ b/entry_test.go
@@ -25,7 +25,7 @@ func TestEntry_All(t *testing.T) {
 		Meta: &MetaData{
 			keySize:    uint32(len("key_0001")),
 			valueSize:  uint32(len("val_0001")),
-			timestamp:  1547707905,
+			Timestamp:  1547707905,
 			TTL:        Persistent,
 			bucket:     []byte("test_entry"),
 			bucketSize: uint32(len("test_datafile")),

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/xujiajun/nutsdb
+module github.com/michaelmukiibi/nutsdb
 
 require (
 	github.com/bwmarrin/snowflake v0.3.0

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/michaelmukiibi/nutsdb
+module github.com/michaelmukiibi2018/nutsdb
 
 require (
 	github.com/bwmarrin/snowflake v0.3.0

--- a/record.go
+++ b/record.go
@@ -24,7 +24,7 @@ type Record struct {
 
 // IsExpired returns the record if expired or not.
 func (r *Record) IsExpired() bool {
-	return IsExpired(r.H.meta.TTL, r.H.meta.timestamp)
+	return IsExpired(r.H.meta.TTL, r.H.meta.Timestamp)
 }
 
 // IsExpired checks the ttl if expired or not.

--- a/tx.go
+++ b/tx.go
@@ -173,7 +173,7 @@ func (tx *Tx) Commit() error {
 			}
 		}
 
-		if entry.Meta.ds == DataStructureBPTree {
+		if entry.Meta.Ds == DataStructureBPTree {
 			tx.db.BPTreeKeyEntryPosMap[string(entry.Meta.bucket)+string(entry.Key)] = tx.db.ActiveFile.writeOff
 		}
 
@@ -202,7 +202,7 @@ func (tx *Tx) Commit() error {
 		}
 
 		if i == lastIndex {
-			txID := entry.Meta.txID
+			txID := entry.Meta.TxID
 			if tx.db.opt.EntryIdxMode == HintBPTSparseIdxMode {
 				if err := tx.buildTxIDRootIdx(txID, countFlag); err != nil {
 					return err
@@ -221,7 +221,7 @@ func (tx *Tx) Commit() error {
 			e = entry
 		}
 
-		if entry.Meta.ds == DataStructureBPTree {
+		if entry.Meta.Ds == DataStructureBPTree {
 			tx.buildBPTreeIdx(bucket, entry, e, off, countFlag)
 		}
 	}
@@ -344,15 +344,15 @@ func (tx *Tx) buildIdxes(writesLen int) {
 
 		bucket := string(entry.Meta.bucket)
 
-		if entry.Meta.ds == DataStructureSet {
+		if entry.Meta.Ds == DataStructureSet {
 			tx.buildSetIdx(bucket, entry)
 		}
 
-		if entry.Meta.ds == DataStructureSortedSet {
+		if entry.Meta.Ds == DataStructureSortedSet {
 			tx.buildSortedSetIdx(bucket, entry)
 		}
 
-		if entry.Meta.ds == DataStructureList {
+		if entry.Meta.Ds == DataStructureList {
 			tx.buildListIdx(bucket, entry)
 		}
 
@@ -600,14 +600,14 @@ func (tx *Tx) put(bucket string, key, value []byte, ttl uint32, flag uint16, tim
 		Meta: &MetaData{
 			keySize:    uint32(len(key)),
 			valueSize:  uint32(len(value)),
-			timestamp:  timestamp,
+			Timestamp:  timestamp,
 			Flag:       flag,
 			TTL:        ttl,
 			bucket:     []byte(bucket),
 			bucketSize: uint32(len(bucket)),
 			status:     UnCommitted,
-			ds:         ds,
-			txID:       tx.id,
+			Ds:         ds,
+			TxID:       tx.id,
 		},
 	})
 


### PR DESCRIPTION
This is to foster logging.

In a web app, when a user access the database in any way, the transaction is logged together with their credentials; let's say. 
Ds is made available outside Meta to allow getting all records in a bucket for structures that do not explicitly allow for this i.e. lists and members - I think. And also in conjunction with the the TxId field, for logging.